### PR TITLE
feat: adds support for remote endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if err != nil {
 }
 
 // Connect to a MySQL database using the zipkinsql driver wrapper.
-db, err = sql.Open(driverName, "myDSN")
+db, err = sql.Open(driverName, "postgres://user:pass@127.0.0.1:5432/db")
 ```
 
 You can also wrap your own driver with zipkin instrumentation as follows:
@@ -39,6 +39,7 @@ You can also wrap your own driver with zipkin instrumentation as follows:
 import (
     mysql "github.com/go-sql-driver/mysql"
     zipkinsql "github.com/jcchavezs/zipkin-instrumentation-sql"
+    zipkinmodel "github.com/openzipkin/zipkin-go/model"
 )
 
 var (
@@ -49,13 +50,20 @@ var (
 )
 
 // Explicitly wrap the MySQL driver with zipkinsql
-driver = zipkinsql.Wrap(&mysql.MySQLDriver{}, tracer)
+driver = zipkinsql.Wrap(
+    &mysql.MySQLDriver{},
+    tracer,
+    zipkinsql.WithRemoteEndpoint(zipkinmodel.Endpoint{
+        ServiceName: "resultsdb",
+        Port: 5432
+    }),
+)
 
 // Register our zipkinsql wrapper as a database driver
 sql.Register("zipkinsql-mysql", driver)
 
 // Connect to a MySQL database using the zipkinsql driver wrapper
-db, err = sql.Open("zipkinsql-mysql", "myDSN")
+db, err = sql.Open("zipkinsql-mysql", "postgres://user:pass@127.0.0.1:5432/db")
 ```
 
 Projects providing their own abstractions on top of database/sql/driver can also wrap an existing driver.Conn interface directly with zipkinsql.

--- a/driver.go
+++ b/driver.go
@@ -216,7 +216,11 @@ func (c zConn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 func (c zConn) Prepare(query string) (stmt driver.Stmt, err error) {
 	if c.options.AllowRootSpan {
-		span := c.tracer.StartSpan("sql/prepare")
+		span := c.tracer.StartSpan(
+			"sql/prepare",
+			zipkin.Kind(zipkinmodel.Client),
+			zipkin.RemoteEndpoint(c.options.RemoteEndpoint),
+		)
 
 		if c.options.TagQuery {
 			span.Tag("sql.query", query)
@@ -249,7 +253,12 @@ func (c *zConn) PrepareContext(ctx context.Context, query string) (stmt driver.S
 	var span zipkin.Span
 	setSpanDefaultTags(span, c.options.DefaultTags)
 	if c.options.AllowRootSpan || zipkin.SpanFromContext(ctx) != nil {
-		span, ctx = c.tracer.StartSpanFromContext(ctx, "sql/prepare")
+		span, ctx = c.tracer.StartSpanFromContext(
+			ctx,
+			"sql/prepare",
+			zipkin.Kind(zipkinmodel.Client),
+			zipkin.RemoteEndpoint(c.options.RemoteEndpoint),
+		)
 		if c.options.TagQuery {
 			span.Tag("sql.query", query)
 		}

--- a/driver_test.go
+++ b/driver_test.go
@@ -7,6 +7,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	zipkin "github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go/model"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter/recorder"
 )
 
@@ -173,6 +174,7 @@ func TestExecContextSuccess(t *testing.T) {
 		{[]TraceOption{WithAllowRootSpan(true), WithRowsAffectedSpan(true)}, 2},
 		{[]TraceOption{WithAllowRootSpan(true), WithLastInsertIDSpan(true), WithRowsAffectedSpan(true)}, 3},
 		{[]TraceOption{WithAllowRootSpan(true), WithLastInsertIDSpan(true), WithRowsAffectedSpan(true), WithTagQuery(true), WithTagQueryParams(true)}, 3},
+		{[]TraceOption{WithAllowRootSpan(true), WithRemoteEndpoint(model.Endpoint{ServiceName: "myservice"})}, 1},
 	}
 	for _, c := range testCases {
 		db, _, recorder := createDB(t, c.opts...)

--- a/options.go
+++ b/options.go
@@ -1,5 +1,9 @@
 package zipkinsql
 
+import (
+	"github.com/openzipkin/zipkin-go/model"
+)
+
 // TraceOption allows for managing zipkinsql configuration using functional options.
 type TraceOption func(o *TraceOptions)
 
@@ -41,6 +45,10 @@ type TraceOptions struct {
 
 	// DefaultTags will be set to each span as default.
 	DefaultTags map[string]string
+
+	// RemoteEndpoint will include the remote endpoint information into the client
+	// span.
+	RemoteEndpoint *model.Endpoint
 }
 
 // WithAllTraceOptions enables all available trace options.
@@ -58,6 +66,7 @@ var AllTraceOptions = TraceOptions{
 	TagQuery:         true,
 	TagQueryParams:   true,
 	TagAffectedRows:  true,
+	RemoteEndpoint:   nil,
 }
 
 // WithOptions sets the zipkinsql tracing middleware options through a single
@@ -125,5 +134,12 @@ func WithTagAffectedRows(b bool) TraceOption {
 func WithDefaultTags(tags map[string]string) TraceOption {
 	return func(o *TraceOptions) {
 		o.DefaultTags = tags
+	}
+}
+
+// WithRemoteEndpoint will be set to each client span
+func WithRemoteEndpoint(e model.Endpoint) TraceOption {
+	return func(o *TraceOptions) {
+		o.RemoteEndpoint = &e
 	}
 }


### PR DESCRIPTION
This PR includes the remote endpoint as part of the options for sql tracer for all client spans. This is a first attempt to fix #7. In a next PR we will include the `Profile` functionality which will improve tracing for specific engines.

Ping @basvanbeek @adriancole