### PR TITLE
Update README.md sqlx.NewDb typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ db, err := sql.Open(driverName, "postgres://localhost:5432/my_database")
 if err != nil { ... }
 
 // Keep the driver name!
-dbx := sqlx.NewDB(db, "postgres")
+dbx := sqlx.NewDb(db, "postgres")
 ```
 
 ## Usage of *Context methods


### PR DESCRIPTION
Hi, great project!
I noticed this small typo, sqlx is [NewDb](https://github.com/jmoiron/sqlx/blob/master/sqlx.go#L251) not NewDB